### PR TITLE
Added --chdir to start-stop-daemon

### DIFF
--- a/examples/node-upstart.conf
+++ b/examples/node-upstart.conf
@@ -24,4 +24,4 @@ end script
 respawn
 
 # Start the process
-exec start-stop-daemon --start --chuid node --make-pidfile --pidfile /var/opt/node/run/node-upstart.pid --exec /home/node/local/node/bin/node -- /home/node/apps/node-upstart.js >> /var/opt/node/log/node-upstart.log 2>&1
+exec start-stop-daemon --chdir /home/node/apps --start --chuid node --make-pidfile --pidfile /var/opt/node/run/node-upstart.pid --exec /home/node/local/node/bin/node -- /home/node/apps/node-upstart.js >> /var/opt/node/log/node-upstart.log 2>&1


### PR DESCRIPTION
I needed to set the directory root of the node application for relevant file paths in various includes. 

There is a switch on start-stop-daemon that provides this capability. Other "how-to's" suggested setting `chdir /path/to/app` in the script part of the upstart conf but it was ignored by `start-stop-daemon`.
