### PR TITLE
Update node-upstart.conf

### DIFF
--- a/examples/node-upstart.conf
+++ b/examples/node-upstart.conf
@@ -14,7 +14,7 @@ stop on runlevel [06]
 #   Create directories for logging and process management
 #   Change ownership to the user running the process
 pre-start script
-    mkdir -p /var/opt/node
+#    mkdir -p /var/opt/node # DRY -p would create 'node', when it creates 'log' below, if either do not exist
     mkdir -p /var/opt/node/log
     mkdir -p /var/opt/node/run
     chown -R node:node /var/opt/node


### PR DESCRIPTION
DRY
mkdir -p would create 'node', when it creates 'log' on line 18
